### PR TITLE
declare Globals to be the default symbol dictionary for Sparkle (and RSR)

### DIFF
--- a/rowan/projects/RemoteServiceReplication.ston
+++ b/rowan/projects/RemoteServiceReplication.ston
@@ -10,5 +10,12 @@ RwLoadSpecificationV2 {
 	#customConditionalAttributes : [
 		'tests'
 	],
+	#platformProperties : {
+		'gemstone' : {
+			'allusers' : {
+				#defaultSymbolDictName : 'Globals'
+			}
+		}
+	},
 	#comment : 'RemoteServiceReplication development load spec'
 }

--- a/rowan/specs/Sparkle.ston
+++ b/rowan/specs/Sparkle.ston
@@ -10,5 +10,12 @@ RwLoadSpecificationV2 {
 	#customConditionalAttributes : [
 		'tests'
 	],
+	#platformProperties : {
+		'gemstone' : {
+			'allusers' : {
+				#defaultSymbolDictName : 'Globals'
+			}
+		}
+	},
 	#comment : 'Sparkle development load spec'
 }


### PR DESCRIPTION
fix #28 ... the actual symbol dictionary changes won't show up until you do a build from scratch ...