### PR TITLE
GemTalk/RemoteServiceReplication#99: add CompileWarning check to src-gs/installSparkle.topaz

### DIFF
--- a/src-gs/installSparkle.topaz
+++ b/src-gs/installSparkle.topaz
@@ -1,23 +1,46 @@
 	iferr 1 stk
 	iferr 2 stack
 #	iferr 3 exit 1
+	display resultcheck
 
+	expectvalue true
 	run
+	| warnings |
+	warnings := {}.
+
 	[
 		(Rowan
 			projectFromUrl: 'file:$ROWAN_PROJECTS_HOME/RemoteServiceReplication/rowan/specs/RemoteServiceReplication.ston'
 			gitUrl: 'file:$ROWAN_PROJECTS_HOME/RemoteServiceReplication') load ] 
-		on: Warning do: [:ex | ex resume]
+		on: CompileWarning do: [:ex |
+			(ex description includesString: 'not optimized')
+				ifFalse: [ warnings add: ex asString printString ].
+			ex resume ].
+	warnings isEmpty
+		ifTrue: [ true ]
+		ifFalse: [ 
+			warnings do:[:warning |  GsFile gciLogServer: warning ] ].
 %
 	commit
 
+	expectvalue true
 	run
+	| warnings |
+	warnings := {}.
 	[
 		false ifTrue: [ ^ self ].
 		(Rowan
 			projectFromUrl: 'file:$ROWAN_PROJECTS_HOME/Sparkle/rowan/specs/Sparkle.ston'
 			gitUrl: 'file:$ROWAN_PROJECTS_HOME/Sparkle') load ] 
-		on: Warning do: [:ex | ex resume]
+
+	on: CompileWarning do: [:ex |
+		(ex description includesString: 'not optimized')
+			ifFalse: [ warnings add: ex asString printString ].
+		ex resume ].
+	warnings isEmpty
+		ifTrue: [ true ]
+		ifFalse: [ 
+			warnings do:[:warning |  GsFile gciLogServer: warning ] ].
 %
 	commit
 


### PR DESCRIPTION
fail the load and list CompileWarnings if non-optimized warnings present