### PR TITLE
Removed fixed port from GCI Connections

### DIFF
--- a/src/Sparkle-Presenters/SpkConnectionPresenter.class.st
+++ b/src/Sparkle-Presenters/SpkConnectionPresenter.class.st
@@ -12,7 +12,6 @@ Class {
 		'cancelButton',
 		'connectButton',
 		'disconnectButton',
-		'portText',
 		'setPathButton'
 	],
 	#category : 'Sparkle-Presenters-Presenters'
@@ -211,26 +210,6 @@ SpkConnectionPresenter >> initializeGroupPresenter [
 ]
 
 { #category : 'initialization' }
-SpkConnectionPresenter >> initializeHostAndPortPresenter [
-
-	| labelBox inputBox inputAndLabelBox |
-	inputAndLabelBox := SpkBoxLayout newVertical.
-	labelBox := SpkBoxLayout newHorizontal.
-	labelBox add: (self newLabel label: 'Host:') height: 20.
-	self addHorizontalSpaceTo: labelBox.
-	labelBox add: (self newLabel label: 'Port:') height: 20.
-	inputAndLabelBox add: labelBox.
-	inputBox := SpkBoxLayout newHorizontal.
-	hostText := self newTextInput.
-	inputBox add: hostText height: 30.
-	self addHorizontalSpaceTo: inputBox.
-	portText := self newTextInput.
-	inputBox add: portText height: 30.
-	inputAndLabelBox add: inputBox.
-	self layout add: inputAndLabelBox height: 50
-]
-
-{ #category : 'initialization' }
 SpkConnectionPresenter >> initializeNamePresenter [
 
 	self layout
@@ -248,7 +227,6 @@ SpkConnectionPresenter >> initializePresenters [
 	super initializePresenters.
 	self initializeNamePresenter. 
 	self initializeGroupPresenter.
-	self initializeHostAndPortPresenter.
 ]
 
 { #category : 'initialization' }
@@ -311,8 +289,7 @@ SpkConnectionPresenter >> updateConnectionProfile [
 	connectionProfile
 		name: nameText text;
 		host: hostText text;
-		group: groupText text;
-		port: portText text
+		group: groupText text
 ]
 
 { #category : 'actions' }
@@ -321,5 +298,4 @@ SpkConnectionPresenter >> updateGUI [
 	nameText text: connectionProfile name.
 	hostText text: connectionProfile host.
 	groupText text: connectionProfile group.
-	portText text: connectionProfile port.
 ]

--- a/src/Sparkle-Presenters/SpkConnectionProfile.class.st
+++ b/src/Sparkle-Presenters/SpkConnectionProfile.class.st
@@ -16,8 +16,7 @@ Class {
 		'name',
 		'host',
 		'group',
-		'connection',
-		'port'
+		'connection'
 	],
 	#classVars : [
 		'ProfileAnnouncer',
@@ -105,12 +104,6 @@ SpkConnectionProfile >> connection: anObject [
 	connection := anObject
 ]
 
-{ #category : 'constants' }
-SpkConnectionProfile >> defaultPort [
-
-	^ '29299'
-]
-
 { #category : 'actions' }
 SpkConnectionProfile >> disconnect [
 
@@ -170,8 +163,6 @@ SpkConnectionProfile >> initialize [
 	name := String new.
 	host := String new.
 	group := String new.
-	port := self defaultPort.
-	
 ]
 
 { #category : 'testing' }
@@ -201,18 +192,6 @@ SpkConnectionProfile >> name [
 SpkConnectionProfile >> name: anObject [
 
 	name := anObject
-]
-
-{ #category : 'accessing' }
-SpkConnectionProfile >> port [
-
-	^ port
-]
-
-{ #category : 'accessing' }
-SpkConnectionProfile >> port: anObject [
-
-	port := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/Sparkle-Presenters/SpkDirectConnectionProfile.class.st
+++ b/src/Sparkle-Presenters/SpkDirectConnectionProfile.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : 'SpkDirectConnectionProfile',
 	#superclass : 'SpkConnectionProfile',
 	#instVars : [
+		'port',
 		'inMemory'
 	],
 	#category : 'Sparkle-Presenters-Support'
@@ -22,6 +23,12 @@ SpkDirectConnectionProfile >> connect [
 		(SpkConnectionProfileConnectedAnnouncement new profiles:
 			 (Array with: self)).
 	^ connection
+]
+
+{ #category : 'constants' }
+SpkDirectConnectionProfile >> defaultPort [
+
+	^ '29299'
 ]
 
 { #category : 'displaying' }
@@ -56,6 +63,7 @@ SpkDirectConnectionProfile >> inMemory: anObject [
 SpkDirectConnectionProfile >> initialize [
 
 	super initialize.
+	port := self defaultPort.
 	inMemory := false
 ]
 
@@ -63,6 +71,18 @@ SpkDirectConnectionProfile >> initialize [
 SpkDirectConnectionProfile >> isInsecureProfile [
 
 	^true
+]
+
+{ #category : 'accessing' }
+SpkDirectConnectionProfile >> port [
+
+	^ port
+]
+
+{ #category : 'accessing' }
+SpkDirectConnectionProfile >> port: anObject [
+
+	port := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/Sparkle-Presenters/SpkGCIConnectionProfile.class.st
+++ b/src/Sparkle-Presenters/SpkGCIConnectionProfile.class.st
@@ -151,23 +151,27 @@ SpkGCIConnectionProfile >> path: anObject [
 { #category : 'actions' }
 SpkGCIConnectionProfile >> setupRSRConnection [
 
-	| initiator |
-	session
+	| detailBytes initiator thePort |
+	detailBytes := session
 		executeStringAndFetchResultByteArray:
-		'| acceptor |
-		acceptor := RsrAcceptConnection port: ', port, '.
+		'| acceptor port detailBytes |
+		acceptor := RsrAcceptConnection port: RsrAcceptConnection wildcardPort.
 		acceptor ensureListening.
 		SessionTemps current
 			at: #PendingConnectionAcceptor
 			put: acceptor.
-		ByteArray new: 80'
+		port := acceptor listeningPort.
+		detailBytes := ByteArray new: 18.
+		detailBytes unsigned16At: 1 put: port.
+		detailBytes'
 		maxResultSize: 1024.
 	session executeStringNb:
 		'| connection |
 		connection := (SessionTemps current at: #PendingConnectionAcceptor) waitForConnection.
 		SessionTemps current removeKey: #PendingConnectionAcceptor.
 		connection waitUntilClose.'.
-	initiator := RsrInitiateConnection host: host port: port asInteger.
+	thePort := detailBytes unsignedShortAt: 1 bigEndian: true.
+	initiator := RsrInitiateConnection host: host port: thePort.
 	connection := initiator connect
 ]
 

--- a/src/Sparkle-Presenters/SpkGciConnectionPresenter.class.st
+++ b/src/Sparkle-Presenters/SpkGciConnectionPresenter.class.st
@@ -19,6 +19,18 @@ SpkGciConnectionPresenter class >> connectionProfileClass [
 ]
 
 { #category : 'initialization' }
+SpkGciConnectionPresenter >> initializeHostPresenter [
+
+	self layout
+		add: (self newLabel label: 'Host:')
+		withConstraints: [ :constraints | constraints height: 20 ].
+	hostText := self newTextInput.
+	self layout
+		add: hostText
+		withConstraints: [ :constraints | constraints height: 30 ]
+]
+
+{ #category : 'initialization' }
 SpkGciConnectionPresenter >> initializeNetldiPresenter [
 
 	self layout
@@ -57,6 +69,7 @@ SpkGciConnectionPresenter >> initializePathPresenter [
 SpkGciConnectionPresenter >> initializePresenters [
 
 	super initializePresenters.
+	self initializeHostPresenter.
 	self initializeVersionStoneNetldiPresenters.
 	self initializeUserPasswordPresenter.
 	self initializePathPresenter.
@@ -160,7 +173,6 @@ SpkGciConnectionPresenter >> setFocusOrder [
 		add: nameText;
 		add: groupText;
 		add: hostText;
-		add: portText; 
 		add: versionText;
 		add: stoneText;
 		add: netldiText;

--- a/src/Sparkle-Presenters/SpkInsecureConnectionPresenter.class.st
+++ b/src/Sparkle-Presenters/SpkInsecureConnectionPresenter.class.st
@@ -5,6 +5,7 @@ Class {
 	#name : 'SpkInsecureConnectionPresenter',
 	#superclass : 'SpkConnectionPresenter',
 	#instVars : [
+		'portText',
 		'inMemoryCheckbox'
 	],
 	#category : 'Sparkle-Presenters-Presenters'
@@ -29,6 +30,26 @@ SpkInsecureConnectionPresenter >> inMemoryCheckbox: anObject [
 ]
 
 { #category : 'initialization' }
+SpkInsecureConnectionPresenter >> initializeHostAndPortPresenter [
+
+	| labelBox inputBox inputAndLabelBox |
+	inputAndLabelBox := SpkBoxLayout newVertical.
+	labelBox := SpkBoxLayout newHorizontal.
+	labelBox add: (self newLabel label: 'Host:') height: 20.
+	self addHorizontalSpaceTo: labelBox.
+	labelBox add: (self newLabel label: 'Port:') height: 20.
+	inputAndLabelBox add: labelBox.
+	inputBox := SpkBoxLayout newHorizontal.
+	hostText := self newTextInput.
+	inputBox add: hostText height: 30.
+	self addHorizontalSpaceTo: inputBox.
+	portText := self newTextInput.
+	inputBox add: portText height: 30.
+	inputAndLabelBox add: inputBox.
+	self layout add: inputAndLabelBox height: 50
+]
+
+{ #category : 'initialization' }
 SpkInsecureConnectionPresenter >> initializeInMemoryCheckbox [
 
 	inMemoryCheckbox := self newCheckBox
@@ -45,6 +66,7 @@ SpkInsecureConnectionPresenter >> initializeInMemoryCheckbox [
 SpkInsecureConnectionPresenter >> initializePresenters [
 
 	super initializePresenters.
+	self initializeHostAndPortPresenter.
 	self initializeInMemoryCheckbox.
 	self addVerticalSpaceTo: self layout height: 145. 
 	self initializeButtons.
@@ -67,6 +89,7 @@ SpkInsecureConnectionPresenter >> updateConnectionProfile [
 
 	super updateConnectionProfile.
 	connectionProfile
+		port: portText text;
 		inMemory: inMemoryCheckbox state
 ]
 
@@ -74,5 +97,6 @@ SpkInsecureConnectionPresenter >> updateConnectionProfile [
 SpkInsecureConnectionPresenter >> updateGUI [
 
 	super updateGUI.
+	portText text: connectionProfile port.
 	inMemoryCheckbox state: connectionProfile inMemory
 ]


### PR DESCRIPTION
This PR migrates GCI Connections to use a wildcard port rather than a fixed port provided in the UI. The port options have been moved into the Direct/Insecure GUI and model objects removing them from the GCI GUI and model.

This addresses https://github.com/GemTalk/Sparkle/issues/68.