### PR TITLE
Don't save extraneous state when saving connection profiles

### DIFF
--- a/src/Sparkle-Presenters/SpkConnectionProfile.class.st
+++ b/src/Sparkle-Presenters/SpkConnectionProfile.class.st
@@ -86,6 +86,12 @@ SpkConnectionProfile class >> removeProfiles: connectionProfiles [
 			 connectionProfiles)
 ]
 
+{ #category : 'ston' }
+SpkConnectionProfile class >> stonAllInstVarNames [
+
+	^ self allInstVarNames copyWithout: #taskspace
+]
+
 { #category : 'comparing' }
 SpkConnectionProfile >> = connectionProfile [
 


### PR DESCRIPTION
A saved connection profile shouldn't have state related to the active taskspace or connection.  Ignore `taskspace` inst var when writing out ston profile. One method addition.
