### PR TITLE
Compatibility with latest version of spec

### DIFF
--- a/src/Sparkle-Spextensions/SpkBoxLayout.class.st
+++ b/src/Sparkle-Spextensions/SpkBoxLayout.class.st
@@ -141,7 +141,7 @@ SpkBoxLayout >> beTopToBottom [
 { #category : 'initialization' }
 SpkBoxLayout >> beVertical [
 
-	direction := SpkLayoutDirectionVertical uniqueInstance
+	direction := SpkVerticalLayoutDirection uniqueInstance
 ]
 
 { #category : 'accessing' }
@@ -237,7 +237,7 @@ SpkBoxLayout >> isHorizontal [
 SpkBoxLayout >> isVertical [ 
 	"Answer true if the layout direction is vertical"
 
-	^ self direction = SpkLayoutDirectionVertical uniqueInstance
+	^ self direction = SpkVerticalLayoutDirection uniqueInstance
 ]
 
 { #category : 'placement rules' }

--- a/src/Sparkle-Spextensions/SpkBoxLayout.class.st
+++ b/src/Sparkle-Spextensions/SpkBoxLayout.class.st
@@ -122,7 +122,7 @@ SpkBoxLayout >> announceChildRemoved: aNameOrPresenter atIndex: anInteger [
 { #category : 'initialization' }
 SpkBoxLayout >> beHorizontal [
 
-	direction := SpkLayoutDirectionHorizontal uniqueInstance
+	direction := SpkHorizontalLayoutDirection uniqueInstance
 ]
 
 { #category : 'initialization' }
@@ -230,7 +230,7 @@ SpkBoxLayout >> initialize [
 SpkBoxLayout >> isHorizontal [ 
 	"Answer true if the layout direction is horizontal"
 
-	^ direction = SpkLayoutDirectionHorizontal uniqueInstance
+	^ direction = SpkHorizontalLayoutDirection uniqueInstance
 ]
 
 { #category : 'initialization' }

--- a/src/Sparkle-Spextensions/SpkClassStyle.class.st
+++ b/src/Sparkle-Spextensions/SpkClassStyle.class.st
@@ -2,15 +2,15 @@
 Style class that knows how to search for its styles by name.
 "
 Class {
-	#name : 'SpkStyleClass',
-	#superclass : 'SpStyleClass',
+	#name : 'SpkClassStyle',
+	#superclass : 'SpClassStyle',
 	#category : 'Sparkle-Spextensions-StyleSheet'
 }
 
 { #category : 'searching' }
-SpkStyleClass >> styleClassNamed: desiredName [
+SpkClassStyle >> styleClassNamed: desiredName [
 
-	"Answer a StyleClass that is my subclass with the given name. There must be exactly one."
+	"Answer a ClassStyle that is my subclass with the given name. There must be exactly one."
 
 	| classes |
 	classes := styles select: [ :aStyle | 

--- a/src/Sparkle-Spextensions/SpkHorizontalLayoutDirection.class.st
+++ b/src/Sparkle-Spextensions/SpkHorizontalLayoutDirection.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : 'SpkHorizontalLayoutDirection',
+	#superclass : 'SpHorizontalLayoutDirection',
+	#category : 'Sparkle-Spextensions-Layouts'
+}

--- a/src/Sparkle-Spextensions/SpkLayoutDirectionHorizontal.class.st
+++ b/src/Sparkle-Spextensions/SpkLayoutDirectionHorizontal.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : 'SpkLayoutDirectionHorizontal',
-	#superclass : 'SpLayoutDirectionHorizontal',
-	#category : 'Sparkle-Spextensions-Layouts'
-}

--- a/src/Sparkle-Spextensions/SpkLayoutDirectionVertical.class.st
+++ b/src/Sparkle-Spextensions/SpkLayoutDirectionVertical.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : 'SpkLayoutDirectionVertical',
-	#superclass : 'SpLayoutDirectionVertical',
-	#category : 'Sparkle-Spextensions-Layouts'
-}

--- a/src/Sparkle-Spextensions/SpkStyleSTONReader.class.st
+++ b/src/Sparkle-Spextensions/SpkStyleSTONReader.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : 'private' }
 SpkStyleSTONReader >> styleClass [
 
-	^ SpkStyleClass
+	^ SpkClassStyle
 ]

--- a/src/Sparkle-Spextensions/SpkVerticalLayoutDirection.class.st
+++ b/src/Sparkle-Spextensions/SpkVerticalLayoutDirection.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : 'SpkVerticalLayoutDirection',
+	#superclass : 'SpVerticalLayoutDirection',
+	#category : 'Sparkle-Spextensions-Layouts'
+}


### PR DESCRIPTION
Spec renamed SpLayoutDirectionVertical, SpLayoutDirectionHorizontal and SpStyleClass, it makes Sparkle installation crash on recent Pharo builds (issue https://github.com/GemTalk/Sparkle/issues/98)

This pull request fixes the issue

One small thing: this PR makes installation instruction obsolete: Pharo 9.0 build 1447 still has old spec class names

I don't know how you manage your work and contributions, so feel free to change anything in my PR